### PR TITLE
document metaformat: Object can only appear once per Item?

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -41,12 +41,12 @@ use std::str;
 use nom::{line_ending, not_line_ending, space, alphanumeric};
 
 #[derive(Debug)]
-pub struct Item<'a> { pub key: &'a str, pub args: Option<&'a str>, pub objs: Vec<&'a str> }
+pub struct Item<'a> { pub key: &'a str, pub args: Option<&'a str>, pub obj: Option<&'a str> }
 named!(pub item <Item>,
     chain!(
         kl:   keyword_line ~
-        objs: many0!(map_res!(object, str::from_utf8)) ,
-        || { Item{ key: kl.key,  args: kl.args, objs: objs } }
+        obj:  opt!(map_res!(object, str::from_utf8)) ,
+        || { Item{ key: kl.key,  args: kl.args, obj: obj } }
     )
 );
 

--- a/src/server_descriptor.rs
+++ b/src/server_descriptor.rs
@@ -189,16 +189,12 @@ fn transmogrify(item_bucket: Vec<Item>) -> ServerDescriptor { // TODO: make this
                 }
             }
 
-            Item { key: "onion-key", args: None, objs: o} => {
-                if let Some(onion_key) = o.first() {
-                    sd.onion_key = Some(onion_key);
-                }
+            Item { key: "onion-key", args: None, obj: Some(o)} => {
+                sd.onion_key = Some(o);
             }
 
-            Item { key: "signing-key", args: None, objs: o} => {
-                if let Some(signing_key) = o.first() {
-                    sd.signing_key = Some(signing_key);
-                }
+            Item { key: "signing-key", args: None, obj: Some(o)} => {
+                sd.signing_key = Some(o);
             }
 
             Item { key: "hidden-service-dir", args, ..} => {
@@ -213,10 +209,8 @@ fn transmogrify(item_bucket: Vec<Item>) -> ServerDescriptor { // TODO: make this
                 sd.ntor_onion_key = Some(args);
             }
 
-            Item { key: "router-signature", args: None, objs: o} => {
-                if let Some(router_signature) = o.first() {
-                    sd.router_signature = Some(router_signature);
-                }
+            Item { key: "router-signature", args: None, obj: Some(o)} => {
+                sd.router_signature = Some(o);
             }
 
             _ => {


### PR DESCRIPTION
The document meta-format states a `KeywordLine` is followed by “zero or more” `Objects`. However, the reality is there may only ever one, and this should properly be “zero or one.”

Need to verify this is _actually_ always the case before merging, ideally with a Tor core developer.
